### PR TITLE
Add export results to Excel

### DIFF
--- a/RepoSkillMiner/Pages/Scan.razor
+++ b/RepoSkillMiner/Pages/Scan.razor
@@ -106,6 +106,8 @@ else
             <p></p>
             <SfProgressButton Content="Scan" IsPrimary="true" @onclick="@InitScan"></SfProgressButton>
             <p></p>
+            <SfButton Content="Export to Excel" IsPrimary="true" @onclick="@ExportToExcel"></SfButton>
+            <p></p>
             @if (authorsList.Count > 0)
             {
                 <div>
@@ -174,4 +176,9 @@ else
     }
 </style>
 
-
+@code {
+    private async Task ExportToExcel()
+    {
+        await service.ExportToExcel(authorsList);
+    }
+}

--- a/RepoSkillMiner/Pages/Scan.razor.cs
+++ b/RepoSkillMiner/Pages/Scan.razor.cs
@@ -90,6 +90,9 @@ namespace RepoSkillMiner.Pages
 
         [Inject]
         private IScanService service { get; set; }
+
+        [Inject]
+        private IExcelExportService excelExportService { get; set; }
         #endregion Dependency Injection
 
 
@@ -108,6 +111,7 @@ namespace RepoSkillMiner.Pages
             service.LuisKey = Configuration["LuisKey"];
             service.LuisEndPoint = Configuration["LuisEndPoint"];
             AppData.AuthorsAndTechs = await service.ReportFindingsAsync(commitsWithFiles, UseLuis, patchesToScan, authorsList, Http);
+            await ExportToExcel();
         }
 
        
@@ -205,6 +209,11 @@ namespace RepoSkillMiner.Pages
             }
 
             return commitsWithFiles;
+        }
+
+        private async Task ExportToExcel()
+        {
+            await excelExportService.ExportToExcel(authorsList);
         }
 
        

--- a/RepoSkillMiner/Program.cs
+++ b/RepoSkillMiner/Program.cs
@@ -25,6 +25,7 @@ namespace RepoSkillMiner
             builder.Services.AddSingleton<AppData>();
             builder.Services.AddSingleton<AppState>();
             builder.Services.AddSyncfusionBlazor();
+            builder.Services.AddScoped<IExcelExportService, ExcelExportService>();
             await builder.Build().RunAsync();
         }
     }

--- a/RepoSkillMiner/Services/ExcelExportService.cs
+++ b/RepoSkillMiner/Services/ExcelExportService.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GithubModels;
+using OfficeOpenXml;
+
+namespace RepoSkillMiner.Services
+{
+    public class ExcelExportService : IExcelExportService
+    {
+        public async Task ExportToExcel(List<AuthorsAndTechs> authorsAndTechs)
+        {
+            using (var package = new ExcelPackage())
+            {
+                var worksheet = package.Workbook.Worksheets.Add("AuthorsAndTechs");
+
+                // Add headers
+                worksheet.Cells[1, 1].Value = "Login";
+                worksheet.Cells[1, 2].Value = "Avatar URL";
+                worksheet.Cells[1, 3].Value = "Technologies";
+
+                // Add data
+                for (int i = 0; i < authorsAndTechs.Count; i++)
+                {
+                    var author = authorsAndTechs[i];
+                    worksheet.Cells[i + 2, 1].Value = author.Login;
+                    worksheet.Cells[i + 2, 2].Value = author.Avatar_url;
+                    worksheet.Cells[i + 2, 3].Value = string.Join(", ", author.Technologies.Select(t => $"{t.Name} ({t.Count})"));
+                }
+
+                // Save the file
+                var file = new FileInfo("AuthorsAndTechs.xlsx");
+                await package.SaveAsAsync(file);
+            }
+        }
+    }
+}

--- a/RepoSkillMiner/Services/IExcelExportService.cs
+++ b/RepoSkillMiner/Services/IExcelExportService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GithubModels;
+
+namespace RepoSkillMiner.Services
+{
+    public interface IExcelExportService
+    {
+        Task ExportToExcel(List<AuthorsAndTechs> authorsAndTechs);
+    }
+}


### PR DESCRIPTION
Add functionality to export scan results to Excel.

* **RepoSkillMiner/Pages/Scan.razor**
  - Add a button to export the results to Excel.
  - Add a method to handle the button click event and export the results to Excel.

* **RepoSkillMiner/Pages/Scan.razor.cs**
  - Add a method to export the results to Excel.
  - Update the `InitScan` method to call the export method after scanning.
  - Inject `IExcelExportService` for dependency injection.

* **RepoSkillMiner/Services/ExcelExportService.cs**
  - Create a new service to handle exporting data to Excel.
  - Add a method to export a list of `AuthorsAndTechs` to an Excel file.

* **RepoSkillMiner/Services/IExcelExportService.cs**
  - Create an interface for the `ExcelExportService`.
  - Add a method signature for exporting a list of `AuthorsAndTechs` to an Excel file.

* **RepoSkillMiner/Program.cs**
  - Register the `ExcelExportService` with the dependency injection container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/melkor54248/RepoSkillMiner/pull/11?shareId=7351e3b2-3cb8-4074-b0eb-502dceb76363).